### PR TITLE
Add basic authentication middleware

### DIFF
--- a/harstorage/config/deployment.ini_tmpl
+++ b/harstorage/config/deployment.ini_tmpl
@@ -35,6 +35,9 @@ beaker.session.secret = ${app_instance_secret}
 
 app_instance_uuid = ${app_instance_uuid}
 
+auth_user = foo
+auth_pswd = bar
+
 # Logging configuration
 [loggers]
 keys = root

--- a/harstorage/config/middleware.py
+++ b/harstorage/config/middleware.py
@@ -8,6 +8,7 @@ from pylons.wsgiapp import PylonsApp
 from routes.middleware import RoutesMiddleware
 
 from harstorage.config.environment import load_environment
+from harstorage.middleware.auth import AuthMiddleware
 
 
 def make_app(global_conf, full_stack=True, static_files=True, **app_conf):
@@ -24,6 +25,7 @@ def make_app(global_conf, full_stack=True, static_files=True, **app_conf):
     app = SessionMiddleware(app, config)
 
     # CUSTOM MIDDLEWARE HERE (filtered by error handling middlewares)
+    app = AuthMiddleware(app, config)
 
     if asbool(full_stack):
         # Handle Python exceptions

--- a/harstorage/middleware/auth.py
+++ b/harstorage/middleware/auth.py
@@ -1,0 +1,54 @@
+class AuthMiddleware(object):
+    """
+    Basic authentication middleware for the entire application,
+    following the baseline recommended practice at
+    http://wsgi.readthedocs.org/en/latest/specifications/simple_authentication.html
+    """
+    def __init__(self, app, config, realm='site'):
+        self.app = app
+        self.config = config
+        self.realm = realm
+
+    def __call__(self, environ, start_response):
+        def repl_start_response(status, headers, exc_info=None):
+            if status.startswith('401'):
+                remove_header(headers, 'WWW-Authenticate')
+                headers.append(('WWW-Authenticate',
+                    'Basic realm="{}"'.format(self.realm)
+                    )
+                )
+            return start_response(status, headers)
+
+        auth = environ.get('HTTP_AUTHORIZATION')
+
+        if auth:
+            scheme, data = auth.split(None, 1)
+            assert scheme.lower() == 'basic'
+            username, password = data.decode('base64').split(':', 1)
+
+            if not self.check_password(username, password):
+                return self.authenticate(environ, start_response)
+            environ['REMOTE_USER'] = username
+            del environ['HTTP_AUTHORIZATION']
+
+            return self.app(environ, repl_start_response)
+
+        return self.authenticate(environ, repl_start_response)
+
+    def authenticate(self, environ, start_response):
+        body = 'Please authenticate'
+        headers = [
+            ('content-type', 'text/plain'),
+            ('content-length', str(len(body))),
+            ('WWW-Authenticate', 'Basic realm="{}"'.format(self.realm))]
+        start_response('401 Unauthorized', headers)
+        return [body]
+
+    def check_password(self, username, password):
+        return username == self.config["app_conf"]["auth_user"] and password == self.config["app_conf"]["auth_pswd"]
+
+def remove_header(headers, name):
+    for header in headers:
+        if header[0].lower() == name.lower():
+            headers.remove(header)
+            break


### PR DESCRIPTION
@clytwynec @cgoldberg 

works with: http://foo:bar@localhost:5000
or by passing the credentials in the browser when prompted.

Credentials are configurable in the .ini file specified in the `paster serve config.ini` command.
